### PR TITLE
chore: deploy website from CI

### DIFF
--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -1,0 +1,17 @@
+name: pnpm
+description: 'Setup node & pnpm'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+        run_install: |
+          - recursive: true
+            args: [--frozen-lockfile, --strict-peer-dependencies]
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,22 @@
+name: 'Require Conventional Commits'
+
+on:
+  # `pull_request_target` event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does.
+  # This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow.
+  # This event allows your workflow to do things like label or comment on pull requests from forks.
+  # Avoid using this event if you need to build or run code from the pull request.
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,112 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # path to built static site directory
+  outputDir: out
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  preview:
+    name: Preview
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - run: pnpm build
+      - name: Add to web3.storage
+        uses: web3-storage/add-to-web3@v2
+        id: ipfs
+        with:
+          path_to_add: ${{ env.outputDir }}
+          web3_token: ${{ secrets.WEB3_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update IPFS DNSLink https://staging.web3.storage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npx dnslink-cloudflare --record staging --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_TOKEN }}
+      - name: Deploy preview build to Cloudflare Pages
+        uses: mathiasvr/command-output@v1.1.0
+        id: cloudflare
+        with:
+          run: npx wrangler pages deploy --project-name w3up-website-staging --branch "$GITHUB_REF_NAME" --commit-hash "$GITHUB_SHA" ${{ env.outputDir }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+      - name: Find Cloudflare Pages preview URL
+        uses: mathiasvr/command-output@v1.1.0
+        id: cloudflare_url
+        with:
+          run: egrep -o 'https?://[^ ]+' <(echo "${{ steps.cloudflare.outputs.stdout }}")
+      - name: Find Current Pull Request
+        uses: jwalton/gh-find-current-pr@v1.3.0
+        id: finder
+      - name: Update Preview URLs PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          number: ${{ steps.finder.outputs.pr }}
+          message: |
+            ### Website preview 🔗✨
+            - 🙂 https://w3s.link/ipfs/${{ steps.ipfs.outputs.cid }}
+            - ⛅️ ${{ steps.cloudflare_url.outputs.stdout }}
+
+            [build log](/${{ github.repository }}/actions/runs/${{ github.run_id }})
+      - name: Add Preview URLs as Job Summary
+        run: |
+          echo "
+          ### Website preview 🔗✨
+            - 🙂 https://w3s.link/ipfs/${{ steps.ipfs.outputs.cid }}
+            - ⛅️ ${{ steps.cloudflare_url.outputs.stdout }}
+
+            [build log](/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+
+  changelog:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Changelog
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.tag-release.outputs.releases_created }}
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        id: tag-release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          monorepo-tags: true
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+
+  release:
+    name: Release
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://web3.storage
+    needs:
+      - test
+      - preview
+      - changelog
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - run: pnpm build
+      - name: Deploy preview build to Cloudflare Pages
+        uses: mathiasvr/command-output@v1.1.0
+        id: cloudflare
+        with:
+          run: npx wrangler pages deploy --project-name w3up-website --branch "main" --commit-hash "$GITHUB_SHA" ${{ env.outputDir }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test
+on:
+  workflow_call:
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/pnpm
+      - run: pnpm lint
+      - run: pnpm test

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
+  images: { unoptimized: true },
   reactStrictMode: true,
   experimental: {
     serverComponentsExternalPackages: ['shiki', 'vscode-oniguruma']

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "echo 'no tests yet'"
   },
   "dependencies": {
     "next": "14.0.1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,19 +25,19 @@ const root = await client.uploadDirectory(files)
 console.log(root.toString())
 `.trim()
 
-export function NavLink ({href, children}: {href:string, children: React.ReactNode}) {
+function NavLink ({href, children}: {href:string, children: React.ReactNode}) {
   return <Link href={href} className='inline-block uppercase font-medium text-lg md:text-xl py-4 md:py-2 px-2 mx-2 hover:text-blue-600'>{children}</Link>
 }
 
-export function ButtonLink ({href, className = '', children}: {href:string, className?: string, children: React.ReactNode}) {
+function ButtonLink ({href, className = '', children}: {href:string, className?: string, children: React.ReactNode}) {
   return (
-    <Link className={`inline-block bg-zinc-950 text-white font-bold text-lg px-8 py-2 rounded-full whitespace-nowrap ${className}`} href={href}>
+    <Link className={`inline-block bg-zinc-950/90 hover:bg-black text-white hover:outline outline-white font-bold text-lg px-8 py-2 rounded-full whitespace-nowrap ${className}`} href={href}>
       {children}
     </Link>
   )
 }
 
-export async function CodeBlock ({code, theme = 'dracula-soft', lang = 'javascript'}: {code: string, theme?: Theme, lang?: Lang}) {
+async function CodeBlock ({code, theme = 'dracula-soft', lang = 'javascript'}: {code: string, theme?: Theme, lang?: Lang}) {
   const html = await highlight(code, theme, lang)
   return <div dangerouslySetInnerHTML={{ __html: html }} className='font-mono' />
 }
@@ -135,7 +135,7 @@ export default function Home() {
             <p className='pt-8'><ButtonLink href='/start'>Create an account</ButtonLink></p>
           </div>
           <div className='text-center flex-auto'>
-            <Image alt="Cluster of logos for the technologies that make web3.storage work" src={ImageIconCluster} className='hidden lg:block lg:w-full lg:max-w-md opacity-80' />
+            <Image alt="Cluster of logos for the technologies that make web3.storage work" src={ImageIconCluster} className='hidden lg:inline-block lg:w-full lg:max-w-md opacity-80' />
           </div>
         </div>
         <div className='md:flex gap-8 max-w-6xl mx-auto'>
@@ -170,7 +170,7 @@ export default function Home() {
       </section>
 
       <footer className='bg-zinc-950 text-white py-16'>
-        <div className='max-w-5xl mx-auto p-8 md:flex'>
+        <div className='max-w-6xl mx-auto p-8 md:flex'>
           <div className='md:w-1/2 pt-8'>
             <Web3StorageLogo>web3.storage</Web3StorageLogo>
             <p className='pt-6 pr-24 font-light text-lg'>Sign up for free using your email address.</p>


### PR DESCRIPTION
this will
- deploy PRs and main to CF `w3up-website-staging` pages project. This is a new project. we can switch over the `staging.web3.storage` domain to this project.
- deploy PRs and main to IPFS dnslink under staging.web3.storage
- deploy prod to CF `w3up-website` page project. Another new project. We can switch over `web3.storage` domain to this project when ready.

it does not set the dnslink for web3.storage yet. We can add that when ready.

License: MIT