### PR TITLE
feat: add specs link to sidebar

### DIFF
--- a/src/pages/docs/_meta.json
+++ b/src/pages/docs/_meta.json
@@ -4,5 +4,9 @@
   "w3cli": "Command line",
   "w3up-client": "JS Client",
   "how-to": "How to",
-  "concepts": "Concepts"
+  "concepts": "Concepts",
+  "specs": {
+    "title": "Specs",
+    "href": "https://github.com/web3-storage/specs"
+  }
 }

--- a/src/pages/docs/_meta.json
+++ b/src/pages/docs/_meta.json
@@ -6,6 +6,7 @@
   "how-to": "How to",
   "concepts": "Concepts",
   "specs": {
+    "newWindow": true,
     "title": "Specs",
     "href": "https://github.com/web3-storage/specs"
   }


### PR DESCRIPTION
Add an external link to the specs repo to the sidebar so folks can discover them, and as a demo of how to do it.

<img width="431" alt="Screenshot 2023-11-13 at 17 37 38" src="https://github.com/web3-storage/www/assets/58871/6c1e16a9-1e2c-41e4-9d73-3f9ee98faf3c">


License: MIT