### PR TITLE
docs: fix links to cli and js client

### DIFF
--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -10,6 +10,6 @@ Building a **JavaScript** or **TypeScript** app? see our [guide to using w3up-cl
 Feeling terminal? Use the [w3cli](/docs/w3cli) command!.
 
 <Cards>
-  <Card icon='💾 ' title="CLI" href="w3cli" />
-  <Card icon='✨ ' title="JS Client" href="w3up-client" />
+  <Card icon='💾 ' title="CLI" href="/docs/w3cli" />
+  <Card icon='✨ ' title="JS Client" href="/docs/w3up-client" />
 </Cards>

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -10,6 +10,6 @@ Building a **JavaScript** or **TypeScript** app? see our [guide to using w3up-cl
 Feeling terminal? Use the [w3cli](/docs/w3cli) command!.
 
 <Cards>
-  <Card icon='💾 ' title="CLI" href="./w3cli" />
-  <Card icon='✨ ' title="JS Client" href="./w3up-client" />
+  <Card icon='💾 ' title="CLI" href="/docs/w3cli" />
+  <Card icon='✨ ' title="JS Client" href="/docs/w3up-client" />
 </Cards>

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -10,6 +10,6 @@ Building a **JavaScript** or **TypeScript** app? see our [guide to using w3up-cl
 Feeling terminal? Use the [w3cli](/docs/w3cli) command!.
 
 <Cards>
-  <Card icon='💾 ' title="CLI" href="/docs/w3cli" />
-  <Card icon='✨ ' title="JS Client" href="/docs/w3up-client" />
+  <Card icon='💾 ' title="CLI" href="w3cli" />
+  <Card icon='✨ ' title="JS Client" href="w3up-client" />
 </Cards>


### PR DESCRIPTION
Issue: CLI and JS client links are failing at bottom of: https://web3.storage/docs/

@travis thought removing the "./" would fix the issue
     - this did not work

current temporary solution is throwing "/docs/" before 
