### PR TITLE
docs: fix broken links on technical documentation 

### DIFF
--- a/src/pages/docs/concepts/filecoin-storage.md
+++ b/src/pages/docs/concepts/filecoin-storage.md
@@ -9,5 +9,3 @@ Because of the open nature of the Filecoin network allowing anyone to participat
 The great thing about IPFS is that, regardless of where your data is sitting (on web3.storage's dedicated servers, Filecoin, on your local IPFS node, or anywhere else), you access your data the same way - using the data's content address - and allows you to tune how many copies you have if you'd like, which has tradeoffs in terms of cost, availability, and read performance!
 
 When storing data on Filecoin, you enter storage "deals" that have a finite duration. web3.storage service currently renews deals for you to ensure your data deals never expire.
-
-<https://web3.storage/docs/concepts/w3link/>

--- a/src/pages/docs/concepts/ucans-and-web3storage.md
+++ b/src/pages/docs/concepts/ucans-and-web3storage.md
@@ -1,6 +1,6 @@
 # UCANs and web3.storage
 
-For authorization, w3up services use [ucanto](https://github.com/web3-storage/ucanto), a Remote Procedure Call (RPC) framework built around [UCAN](https://ucan.xzy/), or User Controlled Authorization Networks. UCANs are a powerful capability-based authorization system that allows fine-grained sharing of permissions through a process called _delegation_ on top of [public key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography).
+For authorization, w3up services use [ucanto](https://github.com/web3-storage/ucanto), a Remote Procedure Call (RPC) framework built around [UCAN](https://ucan.xyz/), or User Controlled Authorization Networks. UCANs are a powerful capability-based authorization system that allows fine-grained sharing of permissions through a process called _delegation_ on top of [public key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography).
 
 You can think about UCAN replacing bearer tokens in traditional APIs for authorization with w3up. Since any actor can be represented by a cryptographic keypair and permissions can be delegated to them, users can interact with w3up directly in cases where a developer might have needed to previously run additional back-end infrastructure to keep API keys secure. This can be extended even to have end users using applications integrated with w3up using their own keypair-based identity.
 

--- a/src/pages/docs/how-to/list.md
+++ b/src/pages/docs/how-to/list.md
@@ -1,6 +1,6 @@
 # How to list files uploaded to web3.storage
 
-In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've [stored some files](https://web3.storage/docs/how-tos/store/) using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
+In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've [stored some files](https://web3.storage/docs/how-to/store/) using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
 
 - Programmatically using the web3.storage client or CLI
 - Using the web3.storage console

--- a/src/pages/docs/how-to/list.md
+++ b/src/pages/docs/how-to/list.md
@@ -1,6 +1,6 @@
 # How to list files uploaded to web3.storage
 
-In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've [stored some files](https://web3.storage/docs/how-to/store/) using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
+In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've [stored some files](/docs/how-to/store/) using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
 
 - Programmatically using the web3.storage client or CLI
 - Using the web3.storage console

--- a/src/pages/docs/how-to/list.md
+++ b/src/pages/docs/how-to/list.md
@@ -1,6 +1,6 @@
 # How to list files uploaded to web3.storage
 
-In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've [stored some files](/docs/how-to/store/) using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
+In this how-to guide, you'll learn about the different ways that you can list the files that you've uploaded to web3.storage. Once you've stored some files using web3.storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
 
 - Programmatically using the web3.storage client or CLI
 - Using the web3.storage console

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -6,8 +6,8 @@ All data stored using web3.storage is made available for retrieval via [IPFS](ht
 
 - In your browser using an [HTTP gateway](https://web3.storage/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the Saturn dCDN.
-- In your terminal using the [IPFS command-line tools](https://web3.storage/docs/how-to/retrieve/#using-the-ipfs-command-line).
-- In your terminal using [curl or Powershell](https://web3.storage/docs/how-to/retrieve/#using-curl-or-powershell).
+- In your terminal using the [IPFS command-line tools](https://web3.storage/docs/how-to/retrieve/#using-the-ipfs-command).
+- In your terminal using [curl](https://web3.storage/docs/how-to/retrieve/#using-curl).
 
 When retrieving any data, you'll be using the content CID of the upload (prefixed by `bafy…`).
 

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -86,4 +86,4 @@ Replace `<YOUR CID>`, `<FILE NAME>`, and `<OUTPUT FILE>` with their respective v
 
 ## Next steps
 
-Next, you'll learn about how to [list](https://web3.storage/docs/how-to/list/)
+Next, you'll learn about how to [list](/docs/how-to/list/)

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -6,7 +6,7 @@ All data stored using web3.storage is made available for retrieval via [IPFS](ht
 
 - In your browser using an [HTTP gateway](https://web3.storage/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the Saturn dCDN.
-- In your terminal using the [IPFS command-line tools](https://web3.storage/docs/how-to/retrieve/#using-the-ipfs-command).
+- In your terminal using the [IPFS command-line tools](/docs/how-to/retrieve/#using-the-ipfs-command).
 - In your terminal using [curl](https://web3.storage/docs/how-to/retrieve/#using-curl).
 
 When retrieving any data, you'll be using the content CID of the upload (prefixed by `bafy…`).

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -4,7 +4,7 @@ In this how-to guide, you'll learn several methods for retrieving data from web3
 
 All data stored using web3.storage is made available for retrieval via [IPFS](https://ipfs.io/), the InterPlanetary File System. IPFS is a distributed, peer-to-peer network for storing and sharing content-addressed data. This guide shows you several ways to retrieve your data from IPFS:
 
-- In your browser using an [HTTP gateway](https://web3.storage/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
+- In your browser using an [HTTP gateway](/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the Saturn dCDN.
 - In your terminal using the [IPFS command-line tools](/docs/how-to/retrieve/#using-the-ipfs-command).
 - In your terminal using [curl](https://web3.storage/docs/how-to/retrieve/#using-curl).

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -4,10 +4,10 @@ In this how-to guide, you'll learn several methods for retrieving data from web3
 
 All data stored using web3.storage is made available for retrieval via [IPFS](https://ipfs.io/), the InterPlanetary File System. IPFS is a distributed, peer-to-peer network for storing and sharing content-addressed data. This guide shows you several ways to retrieve your data from IPFS:
 
-- In your browser using an [HTTP gateway](https://web3.storage/docs/how-tos/retrieve/#using-an-ipfs-http-gateway).
+- In your browser using an [HTTP gateway](https://web3.storage/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the Saturn dCDN.
-- In your terminal using the [IPFS command-line tools](https://web3.storage/docs/how-tos/retrieve/#using-the-ipfs-command-line).
-- In your terminal using [curl or Powershell](https://web3.storage/docs/how-tos/retrieve/#using-curl-or-powershell).
+- In your terminal using the [IPFS command-line tools](https://web3.storage/docs/how-to/retrieve/#using-the-ipfs-command-line).
+- In your terminal using [curl or Powershell](https://web3.storage/docs/how-to/retrieve/#using-curl-or-powershell).
 
 When retrieving any data, you'll be using the content CID of the upload (prefixed by `bafy…`).
 

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -7,7 +7,7 @@ All data stored using web3.storage is made available for retrieval via [IPFS](ht
 - In your browser using an [HTTP gateway](/docs/how-to/retrieve/#using-an-ipfs-http-gateway).
 - Using the Saturn dCDN.
 - In your terminal using the [IPFS command-line tools](/docs/how-to/retrieve/#using-the-ipfs-command).
-- In your terminal using [curl](https://web3.storage/docs/how-to/retrieve/#using-curl).
+- In your terminal using [curl](/docs/how-to/retrieve/#using-curl).
 
 When retrieving any data, you'll be using the content CID of the upload (prefixed by `bafy…`).
 

--- a/src/pages/docs/how-to/retrieve.md
+++ b/src/pages/docs/how-to/retrieve.md
@@ -86,4 +86,4 @@ Replace `<YOUR CID>`, `<FILE NAME>`, and `<OUTPUT FILE>` with their respective v
 
 ## Next steps
 
-Next, you'll learn about how to [list](https://web3.storage/docs/how-tos/list/)
+Next, you'll learn about how to [list](https://web3.storage/docs/how-to/list/)

--- a/src/pages/docs/how-to/upload.md
+++ b/src/pages/docs/how-to/upload.md
@@ -360,6 +360,4 @@ function makeFileObjects () {
 
 ## Next steps
 
-Learn more about how to fetch your data using the CID in the next section, Retrieve.
-
-<https://web3.storage/docs/how-to/retrieve/>
+Learn more about how to fetch your data using the CID in the next section, [retrieve](https://web3.storage/docs/how-to/retrieve/).

--- a/src/pages/docs/how-to/upload.md
+++ b/src/pages/docs/how-to/upload.md
@@ -362,4 +362,4 @@ function makeFileObjects () {
 
 Learn more about how to fetch your data using the CID in the next section, Retrieve.
 
-<https://web3.storage/docs/how-tos/retrieve/>
+<https://web3.storage/docs/how-to/retrieve/>

--- a/src/pages/docs/how-to/upload.md
+++ b/src/pages/docs/how-to/upload.md
@@ -360,4 +360,4 @@ function makeFileObjects () {
 
 ## Next steps
 
-Learn more about how to fetch your data using the CID in the next section, [retrieve](https://web3.storage/docs/how-to/retrieve/).
+Learn more about how to fetch your data using the CID in the next section, [retrieve](/docs/how-to/retrieve/).


### PR DESCRIPTION
majority of issues were replacing /how-tos/ with /how-to/. 

also, ucan.xzy to ucan.xyz 

also removing w3slink concept URL (which doesn't link to anywhere) from filecoin page. 


follow ups:
- update both Agent and Store links on line 77 in upload.md -> moved to https://github.com/web3-storage/www/issues/42
- [x] line 3 in list.md references a concepts/store document which does not exist (but probably should)