### PR TITLE
fix: add link to SLA at bottom of website

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,7 +55,8 @@ function Footer () {
             <a className='block py-2 hover:text-blue-400' href="/docs/quickstart">Quickstart guide</a>
             <a className='block py-2 hover:text-blue-400' href="/docs/faq">FAQ</a>
             <a className='block py-2 hover:text-blue-400' href="mailto:support@web3.storage">Contact us</a>
-            <a className='block py-2 hover:text-blue-400' href="/docs/terms">Terms of use</a>
+            <a className='block py-2 hover:text-blue-400' href="/docs/terms">Terms of Service</a>
+            <a className='block py-2 hover:text-blue-400' href="/docs/service-level-agreement/">Service Level Agreement</a>
             <a className='block py-2 hover:text-blue-400' href="/docs/privacy-policy">Privacy Policy</a>
             <a className='block py-2 hover:text-blue-400' href="https://status.web3.storage/">Status</a>
           </nav>


### PR DESCRIPTION
- changed "Terms of use" to "Terms of Service"
- added link to Service Level Agreement to bottom of website (currently linked on docs site only)