### PR TITLE
feat: use w3 key create instead of ucan-key ed

### DIFF
--- a/src/pages/docs/concepts/architecture-options.mdx
+++ b/src/pages/docs/concepts/architecture-options.mdx
@@ -25,7 +25,7 @@ w3up-client in backend-\>\>web3.storage w3up service: Upload data
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. [This example](https://github.com/web3-storage/w3up/tree/main/packages/w3up-client#bringing-your-own-agent-and-delegation) shows how to load an identity and a delegation into the client on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/docs/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 After this, once your user uploads data to your backend, you can run any of the upload methods.
@@ -53,7 +53,7 @@ Typically `w3up-client` will be running in your end-user's client code, as well 
 You'll need a registered Space, and your client in the backend to have a delegation to use the Space.
 
 <Callout>
-  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. [This example](https://github.com/web3-storage/w3up/tree/main/packages/w3up-client#bringing-your-own-agent-and-delegation) shows how to load an identity and a delegation into the client on the server.
+  **Recommended**: It's easiest to create and register your Space using [w3cli](https://github.com/web3-storage/w3cli), then create an identity for your server and delegate it the ability to upload to your Space. The [bring your own delegations](/docs/how-to/upload/#bring-your-own-delegations) section shows how to generate an identity, create a delegation and then use it on the server.
 </Callout>
 
 Your backend code can then re-delegate it's capabilities to your users. Your user does not need a registered Space - just an Agent with a delegation from your Space.

--- a/src/pages/docs/go-w3up.mdx
+++ b/src/pages/docs/go-w3up.mdx
@@ -30,10 +30,19 @@ go get github.com/web3.storage/go-ucanto
 
 ## Generate a DID
 
-You can use `ucan-key` to generate a private key and DID for use with the library. Install Node.js and then use the `ucan-key` module:
+Currently the best way to generate a DID is to use the w3up JS CLI:
+
+<Steps>
+### Install w3 CLI
 
 ```sh
-npx ucan-key ed
+npm install -g @web3-storage/w3cli
+```
+
+### Generate a DID
+
+```sh
+w3 key create
 ```
 
 Output should look something like:
@@ -42,6 +51,7 @@ Output should look something like:
 # did:key:z6Mkh9TtUbFJcUHhMmS9dEbqpBbHPbL9oxg1zziWn1CYCNZ2
 MgCb+bRGl02JqlWMPUxCyntxlYj0T/zLtR2tn8LFvw6+Yke0BKAP/OUu2tXpd+tniEoOzB3pxqxHZpRhrZl1UYUeraT0=
 ```
+</Steps>
 
 <Callout>
   Save the private key (starting `Mg...`) to a file `private.key`.
@@ -52,15 +62,15 @@ MgCb+bRGl02JqlWMPUxCyntxlYj0T/zLtR2tn8LFvw6+Yke0BKAP/OUu2tXpd+tniEoOzB3pxqxHZpRh
 Proofs are delegations to your DID enabling it to perform tasks. Currently the best way to obtain proofs that will allow you to interact with the web3.storage API is to use the w3up JS CLI:
 
 <Steps>
-### Generate a DID
-
-[Generate a DID](#generate-a-did) and make a note of it (the string starting with `did:key:...`)
-
 ### Install w3 CLI
 
 ```sh
 npm install -g @web3-storage/w3cli
 ```
+
+### Generate a DID
+
+[Generate a DID](#generate-a-did) and make a note of it (the string starting with `did:key:...`)
 
 ### Create a space
 

--- a/src/pages/docs/how-to/upload.mdx
+++ b/src/pages/docs/how-to/upload.mdx
@@ -118,7 +118,7 @@ In your command line where `w3cli` is configured with the Space you want to use 
 
 ```shell
 # The following command returns what will be your Agent private key and DID
-npx ucan-key ed
+w3 key create
 
 # ❗️ Store the private key (starting "Mg...") in environment variable KEY
 


### PR DESCRIPTION
Updates the docs to use the new `w3 key create` command instead of `ucan-key ed`.

Also updates docs for generating a key and delegation and using it to point to relevant docs on the docs site.