### PR TITLE
feat: update "bring your own delegations" example

### DIFF
--- a/src/pages/docs/how-to/upload.mdx
+++ b/src/pages/docs/how-to/upload.mdx
@@ -139,13 +139,17 @@ w3 delegation create <did_from_ucan-key_command_above> | base64
 Then, when you initialize and configure the client, you can pass in this Agent and UCAN.
 
 ```javascript
+import { StoreMemory } from '@web3-storage/access/stores/store-memory'
 import * as Client from '@web3-storage/w3up-client'
+import { importDAG } from '@ucanto/core/delegation'
+import { CarReader } from '@ipld/car'
 import * as Signer from '@ucanto/principal/ed25519'
 
 async function main () {
   // Load client with specific private key
   const principal = Signer.parse(process.env.KEY)
-  const client = await Client.create({ principal })
+  const store = new StoreMemory()
+  const client = await Client.create({ principal, store })
   // Add proof that this agent has been delegated capabilities on the space
   const proof = await parseProof(process.env.PROOF)
   const space = await client.addSpace(proof)

--- a/src/pages/docs/how-to/upload.mdx
+++ b/src/pages/docs/how-to/upload.mdx
@@ -139,8 +139,8 @@ w3 delegation create <did_from_ucan-key_command_above> | base64
 Then, when you initialize and configure the client, you can pass in this Agent and UCAN.
 
 ```javascript
-import { StoreMemory } from '@web3-storage/access/stores/store-memory'
 import * as Client from '@web3-storage/w3up-client'
+import { StoreMemory } from '@web3-storage/w3up-client/stores'
 import { importDAG } from '@ucanto/core/delegation'
 import { CarReader } from '@ipld/car'
 import * as Signer from '@ucanto/principal/ed25519'


### PR DESCRIPTION
1) Add missing `importDAG` and `CarReader` imports 
2) Use `StoreMemory` in example to avoid annoying `Error: store cannot be used with did:key:z6xyz, stored principal and passed principal must match` error.

I started out trying to do (1) but bumped into the error in (2) after running the test code once. Customers have run into this before and we usually tell them to use `StoreMemory` - I think that's the right thing in this case anyway so this feels like a win!

I'd like to update this one more time once https://github.com/web3-storage/w3up/pull/1266 is released so we can get rid of the dependency on `@web3-storage/access`.

Fixes #63