### PR TITLE
w3cli page says there is no w3cli standalone binaries, but there are go-w3up cli standalone binaries, and links to new section on go-w3up page

### DIFF
--- a/src/pages/docs/go-w3up.mdx
+++ b/src/pages/docs/go-w3up.mdx
@@ -179,3 +179,14 @@ rcpt, _ := client.UploadAdd(
   client.WithProofs(proofs),
 )
 ```
+
+## go-w3up cli
+
+`go-w3up` powers a minimal implementation of a [`w3` cli](./w3cli), though the most supported w3cli is the one written in JavaScript.
+
+Please ensure you [read the documentation for using the Go CLI in the README](https://github.com/web3-storage/go-w3up#cli).
+When using go-w3up cli, you will need to obtain a delegation created by the JS CLI or [console](https://console.web3.storage).
+
+### Standalone Binaries
+
+Pre-compiled, standalone binaries of go-w3up cli are available for MacOS, Linux and Windows: [Download the latest release here](https://github.com/web3-storage/go-w3up/releases/latest).

--- a/src/pages/docs/w3cli.mdx
+++ b/src/pages/docs/w3cli.mdx
@@ -31,13 +31,8 @@ Once the install is complete, you'll have a `w3` command available. Try running 
 
 ### Standalone binaries
 
-<Callout type="warning">
-  These binaries are built from the Go client codebase which is not as fully featured as the JS client.
-</Callout>
-
-Pre-compiled, standalone binaries are now available for MacOS, Linux and Windows: [Download latest release](https://github.com/web3-storage/go-w3up/releases/latest).
-
-Please ensure you [read the documentation for using the Go CLI](https://github.com/web3-storage/go-w3up#cli). These binaries are built from the Go client codebase which is not as fully featured as the JS client. Currently to use the Go CLI tool you will need to obtain a delegation created by the JS CLI or [console](https://console.web3.storage).
+There are currently no standalone binaries for w3cli.
+However, there is a go-w3up cli that supports some features of w3cli and *does* have [standalone binaries](./go-w3up/#standalone-binaries) that may work for use cases that require standalone binaries.
 
 ## Create your first space
 


### PR DESCRIPTION
Motivation:
* I think this is a little clearer about the state of standalone binaries for the full functionality of w3cli, but still makes it clear there is a go-w3up cli that can be used for some use cases requiring standalones.

Attachment
* none. I got some more context on this and now I don't feel that strongly about the change, but wanted to propose something to capture the discussion.